### PR TITLE
Add Redis username/password configuration

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -313,7 +313,7 @@ def redis_test(redis_config):
             ssl=redis_config["ssl"],
             username=redis_config["username"],
             password=redis_config["password"],
-            socket_timeout=redis_config["timeout"]
+            socket_timeout=redis_config["timeout"],
         )
         # basic redis ping test
         rds.ping()
@@ -344,7 +344,7 @@ def cache_read(gameid):
         ssl=cfg["ssl"],
         username=cfg["username"],
         password=cfg["password"],
-        socket_timeout=cfg["timeout"]
+        socket_timeout=cfg["timeout"],
     )
 
     try:
@@ -386,7 +386,7 @@ def cache_write(gameid, data, expiration=config.CACHE_EXPIRATION):
         ssl=cfg["ssl"],
         username=cfg["username"],
         password=cfg["password"],
-        socket_timeout=cfg["timeout"]
+        socket_timeout=cfg["timeout"],
     )
 
     # write cache data and set ttl

--- a/src/run.py
+++ b/src/run.py
@@ -231,6 +231,8 @@ def redis_config():
         cdict["port"] = url.port
         cdict["ssl"] = True
         cdict["timeout"] = config.REDIS_DEFAULT_TIMEOUT
+        cdict["username"] = url.username
+        cdict["password"] = url.password
 
     elif os.environ.get("REDIS_URL"):
         # parse config url
@@ -241,6 +243,8 @@ def redis_config():
         cdict["port"] = url.port
         cdict["ssl"] = False
         cdict["timeout"] = config.REDIS_DEFAULT_TIMEOUT
+        cdict["username"] = url.username
+        cdict["password"] = url.password
 
     elif os.environ.get("REDIS_HOST"):
         # set configuration in dict
@@ -270,6 +274,22 @@ def redis_config():
             # set default configuration in dict
             cdict["timeout"] = config.REDIS_DEFAULT_TIMEOUT
 
+        # check for optional username env
+        if os.environ.get("REDIS_USERNAME"):
+            # set configuration in dict
+            cdict["username"] = os.environ.get("REDIS_USERNAME")
+        else:
+            # set default configuration in dict
+            cdict["username"] = ""
+
+        # check for optional password env
+        if os.environ.get("REDIS_PASSWORD"):
+            # set configuration in dict
+            cdict["password"] = os.environ.get("REDIS_PASSWORD")
+        else:
+            # set default configuration in dict
+            cdict["password"] = ""
+
     else:
         # set failed response
         cdict = False
@@ -291,7 +311,9 @@ def redis_test(redis_config):
             host=redis_config["host"],
             port=redis_config["port"],
             ssl=redis_config["ssl"],
-            socket_timeout=redis_config["timeout"],
+            username=redis_config["username"],
+            password=redis_config["password"],
+            socket_timeout=redis_config["timeout"]
         )
         # basic redis ping test
         rds.ping()
@@ -320,12 +342,21 @@ def cache_read(gameid):
         host=cfg["host"],
         port=cfg["port"],
         ssl=cfg["ssl"],
-        socket_timeout=cfg["timeout"],
+        username=cfg["username"],
+        password=cfg["password"],
+        socket_timeout=cfg["timeout"]
     )
 
     try:
-        # decode bytes to str
+        # get info from cache
         data = rds.get(gameid)
+
+        # return if not found
+        if not data:
+            # return failed status
+            return False
+
+        # decode bytes to str
         data = data.decode("UTF-8")
 
         # return cached data
@@ -353,7 +384,9 @@ def cache_write(gameid, data, expiration=config.CACHE_EXPIRATION):
         host=cfg["host"],
         port=cfg["port"],
         ssl=cfg["ssl"],
-        socket_timeout=cfg["timeout"],
+        username=cfg["username"],
+        password=cfg["password"],
+        socket_timeout=cfg["timeout"]
     )
 
     # write cache data and set ttl


### PR DESCRIPTION
This PR will allow username/password configuration by setting it in the config url or separately in username and password environment variables. Also the incorrect Redis read error has been fixed.