### PR TITLE
Add steamcmd in startup command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,7 @@ jobs:
           heroku_app_name: ${{ secrets.HEROKU_APP_NAME }}
           heroku_email: ${{ secrets.HEROKU_EMAIL }}
           usedocker: true
+          delay: 30
           docker_heroku_process_type: web
 
   warmup-api:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,13 +60,12 @@ jobs:
         run: echo "API_VERSION=$(echo $GITHUB_REF | awk -F '/' '{print $NF}' | cut -c 2-)" >> $GITHUB_ENV
       - name: Store API Version
         run: echo $API_VERSION > src/.version
-      - uses: akhileshns/heroku-deploy@v3.12.12
+      - uses: akhileshns/heroku-deploy@v3.2.6
         with:
           heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
           heroku_app_name: ${{ secrets.HEROKU_APP_NAME }}
           heroku_email: ${{ secrets.HEROKU_EMAIL }}
           usedocker: true
-          delay: 30
           docker_heroku_process_type: web
 
   warmup-api:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
         run: echo "API_VERSION=$(echo $GITHUB_REF | awk -F '/' '{print $NF}' | cut -c 2-)" >> $GITHUB_ENV
       - name: Store API Version
         run: echo $API_VERSION > src/.version
-      - uses: akhileshns/heroku-deploy@v3.2.6
+      - uses: akhileshns/heroku-deploy@v3.12.12
         with:
           heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
           heroku_app_name: ${{ secrets.HEROKU_APP_NAME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,4 @@ COPY --chown=$USER:$USER src/ $HOME/
 
 # Set default container command
 ENTRYPOINT [""]
-CMD gunicorn --workers $WORKERS --threads $THREADS --timeout $TIMEOUT --bind :$PORT run:app
+CMD steamcmd +quit && gunicorn --workers $WORKERS --threads $THREADS --timeout $TIMEOUT --bind :$PORT run:app

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ docker-compose up
 ```
 Now you can reach the SteamCMD API locally on [http://localhost:8080](http://localhost:8080)
 
-To keep it simple, [Black](https://github.com/python/black) is used for code style / formatting. Part of the pipeline
+To keep things simple, [Black](https://github.com/python/black) is used for code style / formatting. Part of the pipeline
 will check if the code is properly formatted according to Black code style. You can install it locally via pip:
 ```
 pip install black

--- a/goss.yaml
+++ b/goss.yaml
@@ -6,15 +6,6 @@ process:
     # optional attributes
     skip: false
 
-port:
-  tcp:8080:
-    # required attributes
-    listening: true
-    # optional attributes
-    ip:
-      - 0.0.0.0
-    skip: false
-
 http:
   http://127.0.0.1:8080/v1/info/740:
     # required attributes

--- a/goss_wait.yaml
+++ b/goss_wait.yaml
@@ -1,0 +1,7 @@
+---
+port:
+  tcp:8080:
+    listening: true
+    ip:
+      - 0.0.0.0
+    skip: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-
 gunicorn
 redis
 semver


### PR DESCRIPTION
To avoid a very long first request after the container has been started for the first time, the `steamcmd +quit` command could be run in the start command of the container just before the application starts.

This PR will add this command to the default `CMD` of the Dockerfile that creates the actual Docker image.