### PR TITLE
Upgrade base Ubuntu image from 18.04 to 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Set the base image steamcmd
-FROM steamcmd/steamcmd:ubuntu-18
+FROM steamcmd/steamcmd:ubuntu-20
 
 # Set environment variables
 ENV USER steamcmd


### PR DESCRIPTION
Upgrade base Ubuntu image from 18.04 to 20.04. This will be based on the steamcmd/steamcmd Ubuntu 20.04 image: https://github.com/steamcmd/docker/blob/master/dockerfiles/ubuntu-20/Dockerfile.