### PR TITLE
Remove Deta and add Fly.io deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
+*.pyc
 __pycache__
+.venv
 .deta
 .env

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,43 +45,14 @@ jobs:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           DOCKERHUB_REPOSITORY: steamcmd/api
 
-  deploy-deta:
-    name: Deploy Deta
+  deploy-fly:
+    name: Deploy Fly.io
     runs-on: ubuntu-20.04
-    needs: check-requirements
+    needs: [check-requirements, build-image]
     steps:
       - uses: actions/checkout@v3
+      - uses: unionai-oss/flytectl-setup-action@master
       - name: Parse API Version
         run: echo "API_VERSION=$(echo $GITHUB_REF | awk -F '/' '{print $NF}' | cut -c 2-)" >> $GITHUB_ENV
-      - name: Copy requirements file to source dir
-        run: cp requirements.txt src/
-      - name: Deploy API on Deta
-        uses: HarshKapadia2/deta-deploy@v1.0.2
-        with:
-          deta-access-token: ${{ secrets.DETA_ACCESS_TOKEN }}
-          deta-name: '${{ secrets.DETA_MICRO_NAME }}'
-          deta-project: '${{ secrets.DETA_PROJECT_NAME }}'
-          deta-project-dir: 'src'
-      - name: Prepare environment file
-        run: |
-          cat > src/.env<< EOF
-          # general
-          VERSION=${{ env.API_VERSION }}
-
-          # caching
-          CACHE=True
-          CACHE_TYPE=deta
-          CACHE_EXPIRATION=120
-
-          # deta
-          DETA_BASE_NAME="${{ secrets.DETA_BASE_NAME }}"
-          DETA_PROJECT_KEY="${{ secrets.DETA_PROJECT_KEY }}"
-
-          EOF
-      - name: Update environment on Deta
-        uses: jhihyulin/deta-update-env-action@v1.0.0
-        with:
-          deta-access-token: '${{ secrets.DETA_ACCESS_TOKEN }}'
-          deta-name: '${{ secrets.DETA_MICRO_NAME }}'
-          deta-project: '${{ secrets.DETA_PROJECT_NAME }}'
-          deta-project-dir: 'src'
+      - name: Deploy API on Fly.io
+        run: fly deploy --app steamcmd --image steamcmd/api:${{ env.API_VERSION }} -e VERSION=${{ env.API_VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Set the base image steamcmd
-FROM python:3.9
+FROM python:3.10
 
 # Set environment variables
 ENV USER steamcmd
@@ -29,5 +29,4 @@ COPY --chown=$USER:$USER src/ $HOME/
 ##################### INSTALLATION END #####################
 
 # Set default container command
-ENTRYPOINT [""]
 CMD uvicorn --host 0.0.0.0 --port $PORT --workers $WORKERS main:app

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![CodeFactor](https://www.codefactor.io/repository/github/steamcmd/api/badge)](https://www.codefactor.io/repository/github/steamcmd/api)
 [![Code Style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 [![Discord Online](https://img.shields.io/discord/928592378711912488.svg)](https://discord.steamcmd.net)
-[![Service status](https://img.shields.io/uptimerobot/status/m782827237-5067fd1d69e3b1b2e4e40fff)](https://status.steamcmd.net)
 [![Image Size](https://img.shields.io/docker/image-size/steamcmd/api/latest.svg)](https://hub.docker.com/r/steamcmd/api)
 [![GitHub Release](https://img.shields.io/github/v/release/steamcmd/api?label=version)](https://github.com/steamcmd/api/releases)
 [![GitHub Sponsors](https://img.shields.io/github/sponsors/steamcmd)](https://github.com/sponsors/steamcmd)
@@ -10,38 +9,66 @@
 
 # SteamCMD API
 
-Read-only API interface for steamcmd app_info. Updates of the API are
-automatically deployed on Deta via [Github Actions](https://github.com/steamcmd/api/actions)
+Read-only API interface for steamcmd app_info. Updates of this code are
+automatically deployed on Fly.io via [Github Actions](https://github.com/steamcmd/api/actions)
 when a new version has been created on Github.
 
 ## Self-hosting
 
 The easiest way to host the API yourself is using the free cloud platform
-[Deta](https://www.deta.sh). Install the CLI according to the documentation:
-[https://docs.deta.sh/docs/cli/install](https://docs.deta.sh/docs/cli/install).
+[Fly.io](https://fly.io). Install the CLI according to the documentation:
+[https://fly.io/docs/hands-on/install-flyctl/](https://fly.io/docs/hands-on/install-flyctl/).
 
-After installing authenticate locally with the `deta` cli:
+After installing, authenticate locally with the `flyctl` cli:
+```bash
+fly auth login
 ```
-deta login
+Create the app and redis instances (choose your own names):
+```bash
+fly apps create <app-name>
+fly redis create <redis-name>
 ```
-Then use the deploy command:
+Retrieve the Redis connection URL (you will need this later):
+```bash
+fly redis status <redis-name>
+
+Redis
+  ID             = xxxxxxxxxxxxxxxxxx
+  Name           = api
+  Plan           = Free
+  Primary Region = ams
+  Read Regions   = None
+  Eviction       = Enabled
+  Private URL    = redis://default:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx@fly-api.upstash.io   <== Write the password down
 ```
-cd src/
-deta deploy
+Set the required configuration environment variables:
+```bash
+fly secrets set --app <app-name> \
+  CACHE=True \
+  CACHE_TYPE=redis \
+  CACHE_EXPIRATION=120 \
+  REDIS_HOST="fly-api.upstash.io" \
+  REDIS_PORT=6379 \
+  REDIS_PASSWORD="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 ```
+Finally deploy the API Docker image with the latest code:
+```bash
+fly deploy --app <app-name> --image steamcmd/api:latest -e VERSION=1.0.0
+```
+The version is optional and currently only required for the `/v1/version` endpoint.
 
 ## Container
 
 The API can easily be run via a Docker image which contains the API code and the
 `uvicorn` tool to be able to respond to web requests. With every new version of
 the API the Docker images is automatically rebuild and pushed to the Docker Hub:
-```
+```bash
 docker pull steamcmd/api:latest
 ```
-```
+```bash
 docker pull steamcmd/api:1.10.0
 ```
-```
+```bash
 docker run -p 8000:8000 -d steamcmd/api:latest
 ```
 However during development, using Docker Compose is preferred. See the
@@ -66,12 +93,12 @@ VERSION=1.0.0
 
 # caching
 CACHE=True
-CACHE_TYPE=deta
+CACHE_TYPE=redis
 CACHE_EXPIRATION=120
 
 # redis
 REDIS_HOST="your.redis.host.example.com"
-REDIS_PORT=18516
+REDIS_PORT=6379
 REDIS_PASSWORD="YourRedisP@ssword!"
 
 # deta
@@ -82,7 +109,7 @@ DETA_PROJECT_KEY="YourDet@ProjectKey!"
 ## Development
 
 Run the api locally by installing a web server like uvicorn and running it:
-```
+```bash
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
@@ -91,11 +118,12 @@ cd src/
 uvicorn main:app --reload
 ```
 
-The easiest way to spin up the development environment is using Docker compose.
-This will build the image locally, mount the correct directory (`src`) and set
-the required environment variables. If you are on windows you should store the
-repository in the WSL filesystem or it will fail. Execute compose up in the root:
-```
+The easiest way to spin up a complete development environment is using Docker
+compose. This will build the image locally, mount the correct directory (`src`)
+and set the required environment variables. If you are on windows you should
+store the repository in the WSL filesystem or it will fail. Execute compose up
+in the root:
+```bash
 docker compose up
 ```
 Now you can reach the SteamCMD API locally on [http://localhost:8080](http://localhost:8080).
@@ -105,10 +133,10 @@ Now you can reach the SteamCMD API locally on [http://localhost:8080](http://loc
 To keep things simple, [Black](https://github.com/python/black) is used for code
 style / formatting. Part of the pipeline will check if the code is properly
 formatted according to Black code style. You can install it locally via pip:
-```
+```bash
 pip install black
 ```
 And then simply run it agains the Python source code:
-```
+```bash
 black src
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,10 @@ services:
     environment:
       PORT: 8000
       WORKERS: 4
+      VERSION: 9.9.9
+      CACHE: True
+      CACHE_TYPE: redis
+      CACHE_EXPIRATION: 120
       REDIS_HOST: redis
       REDIS_PORT: 6379
       PYTHONUNBUFFERED: "TRUE"

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,37 @@
+app = "steamcmd"
+kill_signal = "SIGINT"
+kill_timeout = 5
+processes = []
+
+[env]
+  PORT = "8000"
+
+[experimental]
+  auto_rollback = true
+
+[[services]]
+  http_checks = []
+  internal_port = 8000
+  processes = ["app"]
+  protocol = "tcp"
+  script_checks = []
+
+  [services.concurrency]
+    hard_limit = 25
+    soft_limit = 20
+    type = "connections"
+
+  [[services.ports]]
+    force_https = true
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  [[services.tcp_checks]]
+    grace_period = "1s"
+    interval = "15s"
+    restart_limit = 0
+    timeout = "2s"

--- a/src/functions.py
+++ b/src/functions.py
@@ -16,7 +16,6 @@ def app_info(app_id):
     try:
         # Sometimes it hangs for 30+ seconds. Normal connection takes about 500ms
         for _ in range(connect_retries):
-
             count = _ + 1
             count = str(count)
 

--- a/src/main.py
+++ b/src/main.py
@@ -17,6 +17,7 @@ load_dotenv()
 # initialise app
 app = FastAPI()
 
+
 # include "pretty" for backwards compatibility
 class PrettyJSONResponse(Response):
     media_type = "application/json"
@@ -34,7 +35,6 @@ class PrettyJSONResponse(Response):
 
 @app.get("/v1/info/{app_id}", response_class=PrettyJSONResponse)
 def read_app(app_id: int, pretty: bool = False):
-
     if "CACHE" in os.environ and os.environ["CACHE"]:
         info = cache_read(app_id)
 


### PR DESCRIPTION
This PR removes configuration for deploying to Deta.sh and adds Fly.io deployment. Also important to note is that the `ENTRYPOINT` value is been removed from the Dockerfile (and kept default) because this was giving issues when deploying to Fly.io.